### PR TITLE
Refactor log streaming to use Redis instead of WebSocket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
       RABBITMQ_URL : amqp://user:password@host.docker.internal:5672/
       RABBITMQ_QUEUE: task_queue
       WEBSOCKET_LOG_URL: ws://host.docker.internal:5002/live
+      REDIS_URL: redis://host.docker.internal:6379/0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pillow
 networkx
 pygraphviz
 pandas
-websocket-client
+redis


### PR DESCRIPTION
Replace WebSocket with Redis for log streaming functionality and update related environment variables accordingly.

Chose Redis Streams insted of pure redis pub-sub as we need some level of persistence of live logs - 2 mins in this code.