### PR TITLE
Migrate to Redis Lists from RabbitMQ for Tasks Queue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       MINIO_URL : host.docker.internal:9000
       MINIO_ACCESS_KEY : minioadmin
       MINIO_SECRET_KEY : minioadmin
-      RABBITMQ_URL : amqp://user:password@host.docker.internal:5672/
-      RABBITMQ_QUEUE: task_queue
       WEBSOCKET_LOG_URL: ws://host.docker.internal:5002/live
       REDIS_URL: redis://host.docker.internal:6379/0
+      REDIS_QUEUE_NAME: task_queue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
-pika
 minio
 psycopg2
 deap
 numpy
 matplotlib
 scoop
-deap
 scikit-learn
 pillow
 networkx


### PR DESCRIPTION
# Issue #5 

Includes Changes for:
- RabbitMQ -> Redis Lists for Tasks Queue
- Redis Lists doesn't support ack mechanism like RabbitMQ, requeued the message back to the queue incase of DB operation failure with an added timeout. Didnt want to overcomplicate by using a DLQ.

#### Sample Execution Video [Link](https://drive.google.com/file/d/1tFe66LohpHoP_FI6LTU2_ZT8DJHLTT3S/view?usp=sharing)

Needs review @Ashrockzzz2003 